### PR TITLE
Version 1.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,10 @@ Scoary is designed to take the gene_presence_absence.csv file from [Roary] (http
 
 ## What's new?
 
+v1.3.0 (1st Jun 2016)
+- Major changes to the pairwise comparisons algorithm. Scoary now calculates the maximum number of contrasting pairs, and given that maximum number tests the maximum number of pairs that SUPPORT A -> B (AB-ab pairs) and the maximum number of pairs that OPPOSE A -> B (Ab-aB pairs). The opposite is true for genes where the odds ratio is < 1 (i.e. that indicate A -> b).
+- The p-values reported from the pairwise comparisons is now a range. It reports the best (lowest) p-value, which comes from the maximum number of supporting pairs and the minimum number of opposing (given a set total), as well as the worst (highest) p-value, which comes from the minimum number of supporting pairs and the maximum number of non-supporting, given a set total number of pairings. It does this at each node in the tree.
+
 v1.2.3 (30th May 2016)
 - Odds ratios should now be correct again. These were behaving strangely since 1.2.0. Apologies.
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Scoary is designed to take the gene_presence_absence.csv file from [Roary] (http
 v1.3.0 (1st Jun 2016)
 - Major changes to the pairwise comparisons algorithm. Scoary now calculates the maximum number of contrasting pairs, and given that maximum number tests the maximum number of pairs that SUPPORT A -> B (AB-ab pairs) and the maximum number of pairs that OPPOSE A -> B (Ab-aB pairs). The opposite is true for genes where the odds ratio is < 1 (i.e. that indicate A -> b).
 - The p-values reported from the pairwise comparisons is now a range. It reports the best (lowest) p-value, which comes from the maximum number of supporting pairs and the minimum number of opposing (given a set total), as well as the worst (highest) p-value, which comes from the minimum number of supporting pairs and the maximum number of non-supporting, given a set total number of pairings. It does this at each node in the tree.
+- Scoary can now print the UPGMA tree that is calculated internally from the Hamming distances of the gene_presence_absence matrix. Do this by using the -u flag.
 
 v1.2.3 (30th May 2016)
 - Odds ratios should now be correct again. These were behaving strangely since 1.2.0. Apologies.
@@ -141,12 +142,12 @@ The results file contains the following columns:
 ## Options
 Scoary can take a number of optional arguments to tweak the output and make sure it performs as intended:
 ```
-usage: SCOARY.py [-h] -t TRAITS -g GENES [-p P_VALUE_CUTOFF]
-                 [-c {Individual,Bonferroni,Benjamini-Hochberg}]
-                 [-m MAX_HITS] [-r RESTRICT_TO] [-s START_COL]
-                 [--delimiter DELIMITER] [--version]
+usage: Scoary.py [-h] [-t TRAITS] [-g GENES] [-p P_VALUE_CUTOFF]
+                 [-c {Individual,Bonferroni,Benjamini-Hochberg}] [-m MAX_HITS]
+                 [-r RESTRICT_TO] [-u] [-s START_COL] [--delimiter DELIMITER]
+                 [--version]
 
-Screen pan-genome for trait-associated genes
+Scoary version v1.3.0 - Screen pan-genome for trait-associated genes
 
 optional arguments:
   -h, --help            show this help message and exit
@@ -174,6 +175,8 @@ optional arguments:
                         Use if you only want to analyze a subset of your
                         strains. SCOARY will read the provided comma-separated
                         table of strains and restrict analyzes to these.
+  -u, --upgma_tree      This flag will cause Scoary to write the calculated
+                        UPGMA tree to a newick file
   -s START_COL, --start_col START_COL
                         On which column in the gene presence/absence file do
                         individual strain info start. Default=15. (1-based
@@ -185,8 +188,8 @@ optional arguments:
                         annotation column, and it is therefore recommended to
                         save your files using semicolon or tab (" ") instead.
                         SCOARY will output files delimited by semicolon
-  --version    
-                        Display Scoary version, then exit
+  --version             Display Scoary version, and exit.
+
 ```
 #### The -r parameter
 The **-r** parameter is particularly useful, as you can use it to restrict your analysis to a subset of your isolates without altering the gene_presence_absence or trait files. Simply provide a single-line csv file (delimited by ",") with the names of the isolates you would like to include in the current analysis.
@@ -203,6 +206,9 @@ This will restrict the current analysis to isolates 1,2,4 and 9, and will omit a
 
 #### The -s parameter
 The **-s** parameter is used to indicate to Scoary which column in the gene_presence_absence.csv file is the _first_ column representing an isolate. By default it is set to 15 (1-based indexing).
+
+#### The -u flag
+Calling Scoary with the **-u** flag will cause it to write a newick file of the UPGMA tree that is calculated internally. The tree is based on pairwise Hamming distances in the gene_presence_absence matrix.
 
 ## Population structure
 Scoary implements the pairwise comparisons algorithm (Read & Nee, 1995; Maddison, 2000) to identify the maximum number of non-intersecting pairs of isolates that contrast in the state of both gene and trait. It does this by creating an UPGMA tree from the information contained in the gene_presence_absence matrix, annotating tips with gene and trait status, and recursively traversing the tree for each gene that were significant in the initial analysis. (i.e. those with p<0.05 if settings are left at default.)

--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ v1.3.0 (1st Jun 2016)
 - Major changes to the pairwise comparisons algorithm. Scoary now calculates the maximum number of contrasting pairs, and given that maximum number tests the maximum number of pairs that SUPPORT A -> B (AB-ab pairs) and the maximum number of pairs that OPPOSE A -> B (Ab-aB pairs). The opposite is true for genes where the odds ratio is < 1 (i.e. that indicate A -> b).
 - The p-values reported from the pairwise comparisons is now a range. It reports the best (lowest) p-value, which comes from the maximum number of supporting pairs and the minimum number of opposing (given a set total), as well as the worst (highest) p-value, which comes from the minimum number of supporting pairs and the maximum number of non-supporting, given a set total number of pairings. It does this at each node in the tree.
 - Scoary can now print the UPGMA tree that is calculated internally from the Hamming distances of the gene_presence_absence matrix. Do this by using the -u flag.
+- The elapsed time will now print when finished.
 
 v1.2.3 (30th May 2016)
 - Odds ratios should now be correct again. These were behaving strangely since 1.2.0. Apologies.

--- a/README.md
+++ b/README.md
@@ -131,7 +131,10 @@ The results file contains the following columns:
 | Bonferroni_p | A p-value adjusted with Bonferroni's method for multiple comparisons correction (An [FWER] (https://en.wikipedia.org/wiki/Familywise_error_rate) type correction) |
 | Benjamini_H_p | A p-value adjusted with Benjamini-Hochberg's method for multiple comparisons correction (An [FDR] (https://en.wikipedia.org/wiki/False_discovery_rate) type correction) |
 | Max_pairwise_comparisons | The maximum number of pairs that contrast in both gene and trait characters that can be drawn on the phylogenetic tree without intersecting lines (Read & Nee, 1995; Maddison, 2000) |
-| Pairwise_comparisons_p | The p-value corresponding to the maximum number of pairs. Treats the trait as a randomly assigned character with p_trait_presence=p_trait_absence=0.5. (Note: This p-value really represents the LOWEST you could get if you only selected pairs based on contrast in the gene character. Use with caution.) |
+| Max_supporting_pairs | The maximum number of these pairs (Max_pairwise_comparisons) that support A->B or A->b, depending on the odds ratio. |
+| Max_opposing_pairs | The maximum number of these pairs (Max_pairwise_comparisons) that oppose A->B or A->b, depending on the odds ratio. |
+| Best_pairwise_comp_p | The p-value corresponding to the highest possible number of supporting pairs and the lowest possible number of opposing pairs, e.g. the lowest p-value you could end up with when picking a set of maximum number of pairs. |
+| Worst_pairwise_comp_p | The p-value corresponding to the lowest possible number of supporting pairs and the highest possible number of opposing pairs, e.g. the highest p-value you could end up with when picking a set of maximum number of pairs. |
 
 
 
@@ -209,6 +212,18 @@ This tells you something about the **number of times** the gene and trait co-eme
 ![A not-so-significant link between gene and trait](https://cloud.githubusercontent.com/assets/14874487/15569716/8c66322a-2332-11e6-8500-5d27828417c7.png)
 
 ![A very significant link between gene and trait](https://cloud.githubusercontent.com/assets/14874487/15569715/8c61f962-2332-11e6-90e7-5c37976071c8.png)
+
+One must also consider that there might be multiple ways of picking the maximum number of contrasting pairs, and of all these possible sets of pairings, some might provide more support for A->B than others. Consider the following tree:
+
+![A best possible pairing](https://cloud.githubusercontent.com/assets/14874487/15708517/271bd3b2-27ff-11e6-9190-8c655622bbfd.png)
+
+The above tree has a maximum of 6 contrasting pairs, and in this tree the pairs have been chosen so that all pairs support A->B. (The presence of the gene caused the presence of the phenotype). However, in this particular tree we could also have picked 6 contrasting pairs where not all pairs supports this. See for example this pairing:
+
+![A worst possible pairing](https://cloud.githubusercontent.com/assets/14874487/15708516/271bf496-27ff-11e6-81d4-7309f2c274cc.png)
+
+The above tree has the same topology and terminal states, and the same number of contrasting pairs, but now we have chosen pairs so that 5 pairs support A->B while 1 pair oppose it (It suggests that A->b / a->B). This is a worst possible pairing which maintains the maximum number of contrasting pairs.
+
+Scoary reports the best (lowest) and worst (highest) p-values, corresponding to the first and the second scenario, respectively. The p-value corresponds to a binomial test using the number of supporting pairs as successes and p=0.5 for each state. A p<0.05 would thus typically be considered as a rejection of the null hypothesis that the expressed phenotype is not associated with the gene.
 
 ## License
 Scoary is freely available under a GPLv3 license.

--- a/Scoary_classes.py
+++ b/Scoary_classes.py
@@ -1,3 +1,131 @@
+import sys
+
+# Note: The Matrix and QuadTree implementations are heavily based on original implementations by Christian Storm Pedersen.
+
+class Matrix:
+	"""
+	A matrix stored as a list of lists
+	"""
+	def __init__(self,dim,elm=sys.maxint):
+		"""
+		Builds empty nxn matrix
+		"""
+		self.undef = sys.maxint
+		self.dim = dim
+		self.data = []
+		for i in xrange(self.dim):
+			self.data.append(self.dim * [elm])
+			
+	def __getitem__(self, i):
+		"""
+		Get row i from Matrix
+		"""
+		return self.data[i]
+				
+	def __str__(self):
+		s = ""
+		for i in xrange(self.dim):
+			for j in xrange(self.dim):
+				s += str(self.data[i][j]) + " "
+			s += "\n"
+		return s.strip("\n")
+
+class QuadTree:
+	"""
+	A basic QuadTree with names
+	"""
+	def __init__(self, dim, names=None):
+		"""
+		Constructs a quad tree of dimension dim and fills it with 0's
+		"""
+		self.undef = sys.maxint
+		self.dim = dim
+		n = self.dim + self.dim % 2
+		if names is None:
+			names = [str(x) for x in xrange(dim)]
+		self.names = names
+		self.level = []
+		while n > 1:
+			n += (n % 2)
+			self.level.append(Matrix(n))
+			n = (n+1) / 2
+			
+	def get_elm(self,i,j):
+		"""
+		Returns the element at position (i,j) in the quad tree
+		"""
+		return self.level[0][i][j]
+		
+	def insert_row(self, i, row):
+		"""
+		Inserts row (of dim elements) as row number i
+		"""
+		curr_row = row
+		for l in self.level:
+			if len(curr_row) % 2 == 1:
+				curr_row.append(self.undef)
+			next_row = []
+			for j in xrange(len(curr_row)):
+				l[i][j] = curr_row[j]
+				if j % 2 == 1:
+					next_row.append(self.quad_min(i,j,l))
+			i /= 2
+			curr_row = next_row
+			
+	def insert_col(self,j,col):
+		"""
+		Inserts col (of dim elements) as col number j
+		"""
+		curr_col = col
+		for l in self.level:
+			if len(curr_col) % 2 == 1:
+				curr_col.append(self.undef)
+			next_col = []
+			for i in xrange(len(curr_col)):
+				l[i][j] = curr_col[i]
+				if i % 2 == 1:
+					next_col.append(self.quad_min(i,j,l))
+			j /= 2
+			curr_col = next_col
+		
+	def min(self):
+		"""
+		Returns minimum element stored in tree
+		"""
+		return self.quad_min(0,0,self.level[-1])
+		
+	def argmin(self):
+		"""
+		Returns coordinates of minimum element in tree
+		"""
+		i = j = 0
+		for l in reversed(self.level[1:]):
+			i, j = self.quad_argmin(i,j,l)
+			i *= 2
+			j *= 2
+		return self.quad_argmin(i,j,self.level[0])
+		
+	def quad_min_all(self, i, j, l):
+		"""
+		Returns the minimum element stored in the quad (i,j) and its coordinates
+		"""
+		# Need even numbers
+		i = (i/2) * 2
+		j = (j/2) * 2
+		return min((l[i][j],i,j), (l[i+1][j],i+1,j), (l[i][j+1],i,j+1), (l[i+1][j+1],i+1,j+1))
+		
+	def quad_min(self,i,j,l):
+		"""
+		Returns the minimum element stored in the quad containing (i,j)
+		"""
+		return self.quad_min_all(i,j,l)[0]
+		
+	def quad_argmin(self,i,j,l):
+		"""
+		Returns the coordinates of the minimum element in the quad containing (i,j)
+		"""
+		return self.quad_min_all(i,j,l)[1:]
+
 class PhyloTree:
 	"""
 	A class that represents a binary tree. Phylotrees can be nested. They can also contain tips at left, right or both nodes.

--- a/Scoary_classes.py
+++ b/Scoary_classes.py
@@ -1,132 +1,3 @@
-
-import sys
-
-# Note: The Matrix and QuadTree implementations are heavily based on original implementations by Christian Storm Pedersen.
-
-class Matrix:
-	"""
-	A matrix stored as a list of lists
-	"""
-	def __init__(self,dim,elm=sys.maxint):
-		"""
-		Builds empty nxn matrix
-		"""
-		self.undef = sys.maxint
-		self.dim = dim
-		self.data = []
-		for i in xrange(self.dim):
-			self.data.append(self.dim * [elm])
-			
-	def __getitem__(self, i):
-		"""
-		Get row i from Matrix
-		"""
-		return self.data[i]
-				
-	def __str__(self):
-		s = ""
-		for i in xrange(self.dim):
-			for j in xrange(self.dim):
-				s += str(self.data[i][j]) + " "
-			s += "\n"
-		return s.strip("\n")
-
-class QuadTree:
-	"""
-	A basic QuadTree with names
-	"""
-	def __init__(self, dim, names=None):
-		"""
-		Constructs a quad tree of dimension dim and fills it with 0's
-		"""
-		self.undef = sys.maxint
-		self.dim = dim
-		n = self.dim + self.dim % 2
-		if names is None:
-			names = [str(x) for x in xrange(dim)]
-		self.names = names
-		self.level = []
-		while n > 1:
-			n += (n % 2)
-			self.level.append(Matrix(n))
-			n = (n+1) / 2
-			
-	def get_elm(self,i,j):
-		"""
-		Returns the element at position (i,j) in the quad tree
-		"""
-		return self.level[0][i][j]
-		
-	def insert_row(self, i, row):
-		"""
-		Inserts row (of dim elements) as row number i
-		"""
-		curr_row = row
-		for l in self.level:
-			if len(curr_row) % 2 == 1:
-				curr_row.append(self.undef)
-			next_row = []
-			for j in xrange(len(curr_row)):
-				l[i][j] = curr_row[j]
-				if j % 2 == 1:
-					next_row.append(self.quad_min(i,j,l))
-			i /= 2
-			curr_row = next_row
-			
-	def insert_col(self,j,col):
-		"""
-		Inserts col (of dim elements) as col number j
-		"""
-		curr_col = col
-		for l in self.level:
-			if len(curr_col) % 2 == 1:
-				curr_col.append(self.undef)
-			next_col = []
-			for i in xrange(len(curr_col)):
-				l[i][j] = curr_col[i]
-				if i % 2 == 1:
-					next_col.append(self.quad_min(i,j,l))
-			j /= 2
-			curr_col = next_col
-		
-	def min(self):
-		"""
-		Returns minimum element stored in tree
-		"""
-		return self.quad_min(0,0,self.level[-1])
-		
-	def argmin(self):
-		"""
-		Returns coordinates of minimum element in tree
-		"""
-		i = j = 0
-		for l in reversed(self.level[1:]):
-			i, j = self.quad_argmin(i,j,l)
-			i *= 2
-			j *= 2
-		return self.quad_argmin(i,j,self.level[0])
-		
-	def quad_min_all(self, i, j, l):
-		"""
-		Returns the minimum element stored in the quad (i,j) and its coordinates
-		"""
-		# Need even numbers
-		i = (i/2) * 2
-		j = (j/2) * 2
-		return min((l[i][j],i,j), (l[i+1][j],i+1,j), (l[i][j+1],i,j+1), (l[i+1][j+1],i+1,j+1))
-		
-	def quad_min(self,i,j,l):
-		"""
-		Returns the minimum element stored in the quad containing (i,j)
-		"""
-		return self.quad_min_all(i,j,l)[0]
-		
-	def quad_argmin(self,i,j,l):
-		"""
-		Returns the coordinates of the minimum element in the quad containing (i,j)
-		"""
-		return self.quad_min_all(i,j,l)[1:]
-			
 class PhyloTree:
 	"""
 	A class that represents a binary tree. Phylotrees can be nested. They can also contain tips at left, right or both nodes.
@@ -137,7 +8,7 @@ class PhyloTree:
 	4. Free path to ab. 
 	5. No free path.
 	"""
-	def __init__(self, leftnode, rightnode, GTC):
+	def __init__(self, leftnode, rightnode, GTC, OR):
 		"""
 		Constructs a phylotree and links it to its left and right nodes
 		"""
@@ -148,18 +19,23 @@ class PhyloTree:
 		elif isinstance(leftnode, PhyloTree):
 			self.leftnode = leftnode
 		else:
-			self.leftnode = PhyloTree(leftnode=leftnode[0], rightnode=leftnode[1], GTC=GTC)
+			self.leftnode = PhyloTree(leftnode=leftnode[0], rightnode=leftnode[1], GTC=GTC, OR=OR)
 		if len(rightnode) == 1:
 			self.rightnode = Tip(GTC[rightnode[0]])
 		elif isinstance(rightnode, PhyloTree):
 			self.rightnode = rightnode
 		else:
-			self.rightnode = PhyloTree(leftnode=rightnode[0], rightnode=rightnode[1], GTC=GTC)
+			self.rightnode = PhyloTree(leftnode=rightnode[0], rightnode=rightnode[1], GTC=GTC, OR=OR)
 		
 		# Initialize the max number of paths. Set to -1 meaning they cannot be reached
+		self.OR = OR
 		self.maxvalues = {"AB": -1, "Ab": -1, "aB": -1, "ab": -1, "0": -1}
+		self.max_propairs = {"AB": -1, "Ab": -1, "aB": -1, "ab": -1, "0": -1}
+		self.max_antipairs = {"AB": -1, "Ab": -1, "aB": -1, "ab": -1, "0": -1}
 		self.calculate_max()
 		self.max_contrasting_pairs = max(self.maxvalues.values())
+		self.max_contrasting_propairs = max(self.max_propairs.values())
+		self.max_contrasting_antipairs = max(self.max_antipairs.values())
 		
 	def calculate_max(self):
 		"""
@@ -167,10 +43,15 @@ class PhyloTree:
 		"""
 		for condition in ["AB","Ab","aB","ab","nofree"]:
 			if condition in ["AB", "Ab", "aB", "ab"]:
-				self.maxvalues[condition] = self.calculate_max_condition(condition)
+				pairings = self.calculate_max_condition(condition)
+				self.maxvalues[condition] = pairings["Total"]
+				self.max_propairs[condition] = pairings["Pro"]
+				self.max_antipairs[condition] = pairings["Anti"]
 			else: # Condition == nofree
-				self.maxvalues["0"] = self.calculate_max_nofree()
-				
+				pairings = self.calculate_max_nofree()
+				self.maxvalues["0"] = pairings["Total"]
+				self.max_propairs["0"] = pairings["Pro"]
+				self.max_antipairs["0"] = pairings["Anti"]
 		
 	def calculate_max_condition(self,condition):
 		"""
@@ -179,46 +60,221 @@ class PhyloTree:
 		Possible_conditions = set(["AB", "Ab", "aB", "ab"])
 		Possible_conditions.remove(condition)
 		Otherconditions = list(Possible_conditions) # Now we have a list of the elements that are NOT condition
-		max_pairs = -1
+		max_pairs_1 = -1
+		max_pairs_2 = -1
+		max_pairs_3 = -1
+		max_pairs_4 = -1
+		max_pairs_5 = -1
+		max_pairs_6 = -1
+		max_pairs_7 = -1
+		max_pairs_8 = -1
+		max_pairs_9 = -1
+		
+		max_propairs_1 = -1
+		max_propairs_2 = -1
+		max_propairs_3 = -1
+		max_propairs_4 = -1
+		max_propairs_5 = -1
+		max_propairs_6 = -1
+		max_propairs_7 = -1
+		max_propairs_8 = -1
+		max_propairs_9 = -1
+		
+		max_antipairs_1 = -1
+		max_antipairs_2 = -1
+		max_antipairs_3 = -1
+		max_antipairs_4 = -1
+		max_antipairs_5 = -1
+		max_antipairs_6 = -1
+		max_antipairs_7 = -1
+		max_antipairs_8 = -1
+		max_antipairs_9 = -1		
+		
 		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues["0"] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues[condition] + self.rightnode.maxvalues["0"] )
-		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues[Otherconditions[0]] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues[condition] + self.rightnode.maxvalues[Otherconditions[0]] )
-		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues[Otherconditions[1]] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues[condition] + self.rightnode.maxvalues[Otherconditions[1]] )
-		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues[Otherconditions[2]] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues[condition] + self.rightnode.maxvalues[Otherconditions[2]] )
-		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues[condition] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues[condition] + self.rightnode.maxvalues[condition] )
-		if self.leftnode.maxvalues["0"] > -1 and self.rightnode.maxvalues[condition] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues["0"] + self.rightnode.maxvalues[condition] )
-		if self.leftnode.maxvalues[Otherconditions[0]] > -1 and self.rightnode.maxvalues[condition] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues[Otherconditions[0]] + self.rightnode.maxvalues[condition] )
-		if self.leftnode.maxvalues[Otherconditions[1]] > -1 and self.rightnode.maxvalues[condition] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues[Otherconditions[1]] + self.rightnode.maxvalues[condition] )
-		if self.leftnode.maxvalues[Otherconditions[2]] > -1 and self.rightnode.maxvalues[condition] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues[Otherconditions[2]] + self.rightnode.maxvalues[condition] )
+			max_pairs_1 = self.leftnode.maxvalues[condition] + self.rightnode.maxvalues["0"]
+			max_propairs_1 = self.leftnode.max_propairs[condition] + self.rightnode.max_propairs["0"]
+			max_antipairs_1 = self.leftnode.max_antipairs[condition] + self.rightnode.max_antipairs["0"]
 			
-		return max_pairs
+		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues[Otherconditions[0]] > -1:
+			max_pairs_2 = self.leftnode.maxvalues[condition] + self.rightnode.maxvalues[Otherconditions[0]]
+			max_propairs_2 = self.leftnode.max_propairs[condition] + self.rightnode.max_propairs[Otherconditions[0]]
+			max_antipairs_2 = self.leftnode.max_antipairs[condition] + self.rightnode.max_antipairs[Otherconditions[0]]
+			
+		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues[Otherconditions[1]] > -1:
+			max_pairs_3 = self.leftnode.maxvalues[condition] + self.rightnode.maxvalues[Otherconditions[1]]
+			max_propairs_3 = self.leftnode.max_propairs[condition] + self.rightnode.max_propairs[Otherconditions[1]]
+			max_antipairs_3 = self.leftnode.max_antipairs[condition] + self.rightnode.max_antipairs[Otherconditions[1]] 
+			
+		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues[Otherconditions[2]] > -1:
+			max_pairs_4 = self.leftnode.maxvalues[condition] + self.rightnode.maxvalues[Otherconditions[2]]
+			max_propairs_4 = self.leftnode.max_propairs[condition] + self.rightnode.max_propairs[Otherconditions[2]]
+			max_antipairs_4 = self.leftnode.max_antipairs[condition] + self.rightnode.max_antipairs[Otherconditions[2]]
+			
+		if self.leftnode.maxvalues[condition] > -1 and self.rightnode.maxvalues[condition] > -1:
+			max_pairs_5 = self.leftnode.maxvalues[condition] + self.rightnode.maxvalues[condition]
+			max_propairs_5 = self.leftnode.max_propairs[condition] + self.rightnode.max_propairs[condition]
+			max_antipairs_5 = self.leftnode.max_antipairs[condition] + self.rightnode.max_antipairs[condition]
+			
+		if self.leftnode.maxvalues["0"] > -1 and self.rightnode.maxvalues[condition] > -1:
+			max_pairs_6 = self.leftnode.maxvalues["0"] + self.rightnode.maxvalues[condition]
+			max_propairs_6 = self.leftnode.max_propairs["0"] + self.rightnode.max_propairs[condition]
+			max_antipairs_6 = self.leftnode.max_antipairs["0"] + self.rightnode.max_antipairs[condition]
+			
+		if self.leftnode.maxvalues[Otherconditions[0]] > -1 and self.rightnode.maxvalues[condition] > -1:
+			max_pairs_7 = self.leftnode.maxvalues[Otherconditions[0]] + self.rightnode.maxvalues[condition]
+			max_propairs_7 = self.leftnode.max_propairs[Otherconditions[0]] + self.rightnode.max_propairs[condition]
+			max_antipairs_7 = self.leftnode.max_antipairs[Otherconditions[0]] + self.rightnode.max_antipairs[condition]
+			
+		if self.leftnode.maxvalues[Otherconditions[1]] > -1 and self.rightnode.maxvalues[condition] > -1:
+			max_pairs_8 = self.leftnode.maxvalues[Otherconditions[1]] + self.rightnode.maxvalues[condition]
+			max_propairs_8 = self.leftnode.max_propairs[Otherconditions[1]] + self.rightnode.max_propairs[condition]
+			max_antipairs_8 = self.leftnode.max_antipairs[Otherconditions[1]] + self.rightnode.max_antipairs[condition]
+			
+		if self.leftnode.maxvalues[Otherconditions[2]] > -1 and self.rightnode.maxvalues[condition] > -1:
+			max_pairs_9 = self.leftnode.maxvalues[Otherconditions[2]] + self.rightnode.maxvalues[condition]
+			max_propairs_9 = self.leftnode.max_propairs[Otherconditions[2]] + self.rightnode.max_propairs[condition]
+			max_antipairs_9 = self.leftnode.max_antipairs[Otherconditions[2]] + self.rightnode.max_antipairs[condition]
+			
+		max_pairs = max(max_pairs_1, max_pairs_2, max_pairs_3, max_pairs_4, max_pairs_5, max_pairs_6, max_pairs_7, max_pairs_8, max_pairs_9)
+		
+		# Calculate maximum number of propairs, given a maxmimum number of pairs
+		max_propairs = -1	
+		if max_pairs == max_pairs_1:	
+			max_propairs = max(max_propairs, max_propairs_1)
+		if max_pairs == max_pairs_2:	
+			max_propairs = max(max_propairs, max_propairs_2)
+		if max_pairs == max_pairs_3:	
+			max_propairs = max(max_propairs, max_propairs_3)
+		if max_pairs == max_pairs_4:	
+			max_propairs = max(max_propairs, max_propairs_4)
+		if max_pairs == max_pairs_5:	
+			max_propairs = max(max_propairs, max_propairs_5)
+		if max_pairs == max_pairs_6:	
+			max_propairs = max(max_propairs, max_propairs_6)
+		if max_pairs == max_pairs_7:	
+			max_propairs = max(max_propairs, max_propairs_7)
+		if max_pairs == max_pairs_8:	
+			max_propairs = max(max_propairs, max_propairs_8)
+		if max_pairs == max_pairs_9:	
+			max_propairs = max(max_propairs, max_propairs_9)
+		
+		# Calculate maximum number of antipairs, given a maxmimum number of pairs
+		max_antipairs = -1	
+		if max_pairs == max_pairs_1:	
+			max_antipairs = max(max_antipairs, max_antipairs_1)
+		if max_pairs == max_pairs_2:	
+			max_antipairs = max(max_antipairs, max_antipairs_2)
+		if max_pairs == max_pairs_3:	
+			max_antipairs = max(max_antipairs, max_antipairs_3)
+		if max_pairs == max_pairs_4:	
+			max_antipairs = max(max_antipairs, max_antipairs_4)
+		if max_pairs == max_pairs_5:	
+			max_antipairs = max(max_antipairs, max_antipairs_5)
+		if max_pairs == max_pairs_6:	
+			max_antipairs = max(max_antipairs, max_antipairs_6)
+		if max_pairs == max_pairs_7:	
+			max_antipairs = max(max_antipairs, max_antipairs_7)
+		if max_pairs == max_pairs_8:	
+			max_antipairs = max(max_antipairs, max_antipairs_8)
+		if max_pairs == max_pairs_9:	
+			max_antipairs = max(max_antipairs, max_antipairs_9)
+			
+		return {"Total" : max_pairs, "Pro": max_propairs, "Anti" : max_antipairs}
 		
 	def calculate_max_nofree(self):
 		"""
 		Under the condition of no free paths, only 5 distinct possibilities exits
 		"""
-		max_pairs = -1
 		# No free pairs in either:
+		max_pairs_nofree = -1
+		max_pairs_1100 = -1
+		max_pairs_0011 = -1
+		max_pairs_1001 = -1
+		max_pairs_0110 = -1
+		
+		max_propairs_nofree = -1
+		max_propairs_1100 = -1
+		max_propairs_0011 = -1
+		max_propairs_1001 = -1
+		max_propairs_0110 = -1
+		
+		max_antipairs_nofree = -1
+		max_antipairs_1100 = -1
+		max_antipairs_0011 = -1
+		max_antipairs_1001 = -1
+		max_antipairs_0110 = -1
+		
+		
 		if self.leftnode.maxvalues["0"] > -1 and self.rightnode.maxvalues["0"] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues["0"] + self.rightnode.maxvalues["0"] )
+			max_pairs_nofree = self.leftnode.maxvalues["0"] + self.rightnode.maxvalues["0"]
+			max_propairs_nofree = self.leftnode.max_propairs["0"] + self.rightnode.max_propairs["0"]
+			max_antipairs_nofree = self.leftnode.max_antipairs["0"] + self.rightnode.max_antipairs["0"]
+		
 		if self.leftnode.maxvalues["AB"] > -1 and self.rightnode.maxvalues["ab"] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues["AB"] + self.rightnode.maxvalues["ab"] + 1 )
+			max_pairs_1100 = self.leftnode.maxvalues["AB"] + self.rightnode.maxvalues["ab"] + 1
+			max_propairs_1100 = self.leftnode.max_propairs["AB"] + self.rightnode.max_propairs["ab"]
+			max_antipairs_1100 = self.leftnode.max_antipairs["AB"] + self.rightnode.max_antipairs["ab"]
+			if self.OR < 1:
+				max_antipairs_1100 += 1
+			else:
+				max_propairs_1100 += 1
+			
 		if self.leftnode.maxvalues["ab"] > -1 and self.rightnode.maxvalues["AB"] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues["ab"] + self.rightnode.maxvalues["AB"] + 1 )
+			max_pairs_0011 = self.leftnode.maxvalues["ab"] + self.rightnode.maxvalues["AB"] + 1
+			max_propairs_0011 = self.leftnode.max_propairs["ab"] + self.rightnode.max_propairs["AB"]
+			max_antipairs_0011 = self.leftnode.max_antipairs["ab"] + self.rightnode.max_antipairs["AB"]
+			if self.OR < 1:
+				max_antipairs_0011 += 1
+			else:
+				max_propairs_0011 += 1
+			
 		if self.leftnode.maxvalues["Ab"] > -1 and self.rightnode.maxvalues["aB"] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues["Ab"] + self.rightnode.maxvalues["aB"] + 1 )
+			max_pairs_1001 = self.leftnode.maxvalues["Ab"] + self.rightnode.maxvalues["aB"] + 1
+			max_propairs_1001 = self.leftnode.max_propairs["Ab"] + self.rightnode.max_propairs["aB"]
+			max_antipairs_1001 = self.leftnode.max_antipairs["Ab"] + self.rightnode.max_antipairs["aB"]# + 1
+			if self.OR < 1:
+				max_propairs_1001 += 1
+			else:
+				max_antipairs_1001 += 1
+			
 		if self.leftnode.maxvalues["aB"] > -1 and self.rightnode.maxvalues["Ab"] > -1:
-			max_pairs = max( max_pairs, self.leftnode.maxvalues["aB"] + self.rightnode.maxvalues["Ab"] + 1 )
-
-		return max_pairs
+			max_pairs_0110 = self.leftnode.maxvalues["aB"] + self.rightnode.maxvalues["Ab"] + 1
+			max_propairs_0110 = self.leftnode.max_propairs["aB"] + self.rightnode.max_propairs["Ab"]
+			max_antipairs_0110 = self.leftnode.max_antipairs["aB"] + self.rightnode.max_antipairs["Ab"]
+			if self.OR < 1:
+				max_propairs_0110 += 1
+			else:
+				max_antipairs_0110 += 1
+			
+		max_pairs = max(max_pairs_nofree, max_pairs_1100, max_pairs_0011, max_pairs_1001, max_pairs_0110)
+		
+		# Calculate max number of propairs
+		max_propairs = -1 # Max_propairs can never go below -1
+		if max_pairs == max_pairs_nofree:
+			max_propairs = max(max_propairs, max_propairs_nofree)
+		if max_pairs == max_pairs_1100:
+			max_propairs = max(max_propairs, max_propairs_1100)
+		if max_pairs == max_pairs_0011:
+			max_propairs = max(max_propairs, max_propairs_0011)
+		if max_pairs == max_pairs_1001:
+			max_propairs = max(max_propairs, max_propairs_1001)
+		if max_pairs == max_pairs_0110:
+			max_propairs = max(max_propairs, max_propairs_0110)
+		
+		# Calculate max number of antipairs
+		max_antipairs = -1 # Max_antipairs can never go below -1
+		if max_pairs == max_pairs_nofree:
+			max_antipairs = max(max_antipairs, max_antipairs_nofree)
+		if max_pairs == max_pairs_1100:
+			max_antipairs = max(max_antipairs, max_antipairs_1100)
+		if max_pairs == max_pairs_0011:
+			max_antipairs = max(max_antipairs, max_antipairs_0011)
+		if max_pairs == max_pairs_1001:
+			max_antipairs = max(max_antipairs, max_antipairs_1001)
+		if max_pairs == max_pairs_0110:
+			max_antipairs = max(max_antipairs, max_antipairs_0110)
+			
+		return {"Total": max_pairs, "Pro": max_propairs, "Anti": max_antipairs}
 	
 class Tip:
 	"""
@@ -235,3 +291,5 @@ class Tip:
 				self.maxvalues[condition] = 0
 			else:
 				self.maxvalues[condition] = -1
+		self.max_propairs = {k:v for k,v in self.maxvalues.items()}
+		self.max_antipairs = {k:v for k,v in self.maxvalues.items()}

--- a/Scoary_methods.py
+++ b/Scoary_methods.py
@@ -433,8 +433,10 @@ def StoreUPGMAtreeToFile(upgmatree):
 	"""
 	A method for printing the UPGMA tree that is built internally from the hamming distances in the gene presence/absence matrix
 	"""
-	with open("Tree" + time.strftime("_%d_%m_%Y_%H%M") + ".nwk", "w") as treefile:
+	treefilename = str("Tree" + time.strftime("_%d_%m_%Y_%H%M") + ".nwk")
+	with open(treefilename, "w") as treefile:
 		Tree = str(upgmatree)
 		Tree = Tree.replace("[","(")
 		Tree = Tree.replace("]",")")
 		treefile.write(Tree)
+		print "Wrote the UPGMA tree to file:", treefilename

--- a/Scoary_methods.py
+++ b/Scoary_methods.py
@@ -30,6 +30,7 @@ def main():
 	parser.add_argument('-m', '--max_hits', help='Maximum number of hits to report. SCOARY will only report the top max_hits results per trait', type=int)
 	parser.add_argument('-r', '--restrict_to', help='Use if you only want to analyze a subset of your strains. SCOARY will read the provided comma-separated table of strains and restrict analyzes to these.')
 	parser.add_argument('-s', '--start_col', help='On which column in the gene presence/absence file do individual strain info start. Default=15. (1-based indexing)', default=15, type=int)
+	parser.add_argument('-u', '--upgma_tree', help='This flag will cause Scoary to write the calculated UPGMA tree to a newick file', default=False, action='store_true')
 	parser.add_argument('--delimiter', help='The delimiter between cells in the gene presence/absence and trait files. NOTE: Even though commas are the default they might mess with the annotation column, and it is therefore recommended to save your files using semicolon or tab ("\t") instead. SCOARY will output files delimited by semicolon', default=',', type=str)
 	parser.add_argument('--version', help='Display Scoary version, and exit.', default=False,action='store_true')
 	
@@ -73,6 +74,9 @@ def main():
 		RES_and_GTC = Setup_results(genedic, traitsdic)
 		RES = RES_and_GTC["Results"]
 		GTC = RES_and_GTC["Gene_trait_combinations"]
+		
+		if args.upgma_tree:
+			StoreUPGMAtreeToFile(upgmatree)
 		
 		StoreResults(RES, args.max_hits, args.p_value_cutoff, args.correction, upgmatree, GTC)
 
@@ -422,3 +426,13 @@ def ConvertUPGMAtoPhyloTree(tree, GTC):
 	print "Max antipairs : " + str(MyPhyloTree.max_contrasting_antipairs)
 	
 	return {"Total" : MyPhyloTree.max_contrasting_pairs, "Pro" : MyPhyloTree.max_contrasting_propairs, "Anti" : MyPhyloTree.max_contrasting_antipairs}
+
+def StoreUPGMAtreeToFile(upgmatree):
+	"""
+	A method for printing the UPGMA tree that is built internally from the hamming distances in the gene presence/absence matrix
+	"""
+	with open("Tree" + time.strftime("_%d_%m_%Y_%H%M") + ".nwk", "w") as treefile:
+		Tree = str(upgmatree)
+		Tree = Tree.replace("[","(")
+		Tree = Tree.replace("]",")")
+		treefile.write(Tree)

--- a/Scoary_methods.py
+++ b/Scoary_methods.py
@@ -343,6 +343,8 @@ def StoreTraitResult(Trait, Traitname, max_hits, p_cutoff, correctionmethod, upg
 		outfile.write("Gene;Non-unique gene name;Annotation;Number_pos_present_in;Number_neg_present_in;Number_pos_not_present_in;" + \
 		"Number_neg_not_present_in;Sensitivity;Specificity;Odds_ratio;p_value;Bonferroni_p;Benjamini_H_p;Max_Pairwise_comparisons;" + \
 		"Max_supporting_pairs;Max_opposing_pairs;Best_pairwise_comp_p;Worst_pairwise_comp_p\n")
+		
+		print "Calculating max number of contrasting pairs for each significant gene"
 
 		for x in xrange(num_results):
 			# Start with lowest p-value, the one which has key 0 in sort_instructions

--- a/Scoary_methods.py
+++ b/Scoary_methods.py
@@ -49,6 +49,8 @@ def main():
 			print "error: argument -g/--genes is required"
 		sys.exit(1)
 	
+	starttime = time.time()
+	
 	with open(args.genes, "rU") as genes, open(args.traits, "rU") as traits:
 		
 		if args.restrict_to is not None:
@@ -79,8 +81,9 @@ def main():
 			StoreUPGMAtreeToFile(upgmatree)
 		
 		StoreResults(RES, args.max_hits, args.p_value_cutoff, args.correction, upgmatree, GTC)
-
-	sys.exit("Finished")
+		print "Finished. Checked a total of", len(genedic), "genes for associations to", len(traitsdic), "trait(s). Total time used:",int(time.time()-starttime),"seconds."
+	
+	sys.exit(0)
 
 def CreateTriangularDistanceMatrix(zeroonesmatrix,strainnames):
 	"""

--- a/Scoary_methods.py
+++ b/Scoary_methods.py
@@ -421,9 +421,6 @@ def ConvertUPGMAtoPhyloTree(tree, GTC):
 	num_ab = float(GTC.values().count("ab"))
 	OR = ((num_AB + 1)/(num_Ab + 1)) / ((num_aB + 1)/(num_ab + 1)) # Use pseudocounts to avoid 0 or inf OR.
 	MyPhyloTree = PhyloTree(leftnode=tree[0], rightnode=tree[1], GTC=GTC, OR=OR)
-	print "Max contrasting pairs : " + str(MyPhyloTree.max_contrasting_pairs)
-	print "Max propairs : " + str(MyPhyloTree.max_contrasting_propairs)
-	print "Max antipairs : " + str(MyPhyloTree.max_contrasting_antipairs)
 	
 	return {"Total" : MyPhyloTree.max_contrasting_pairs, "Pro" : MyPhyloTree.max_contrasting_propairs, "Anti" : MyPhyloTree.max_contrasting_antipairs}
 

--- a/Scoary_methods.py
+++ b/Scoary_methods.py
@@ -350,9 +350,9 @@ def StoreTraitResult(Trait, Traitname, max_hits, p_cutoff, correctionmethod, upg
 			max_total_pairs = Max_pairwise_comparisons["Total"]
 			max_propairs = Max_pairwise_comparisons["Pro"]
 			max_antipairs = Max_pairwise_comparisons["Anti"]
-			best_pairwise_comparison_p = special.binom(max_total_pairs,max_propairs) * (0.5 ** max_propairs) * (0.5 ** (max_total_pairs - max_propairs))
-			worst_pairwise_comparison_p = special.binom(max_total_pairs,(max_total_pairs - max_antipairs)) * (0.5 ** (max_total_pairs - max_antipairs)) * (0.5 ** max_antipairs)
-			
+			best_pairwise_comparison_p = ss.binom_test(max_propairs, max_total_pairs, 0.5, alternative="greater")
+			worst_pairwise_comparison_p = ss.binom_test(max_total_pairs-max_antipairs, max_total_pairs, 0.5, alternative="greater")
+
 			outfile.write('"' + currentgene + '";"' + str(Trait[currentgene]["NUGN"]) + '";"' + str(Trait[currentgene]["Annotation"]) + \
 			'";"' + str(Trait[currentgene]["tpgp"]) + '";"' + str(Trait[currentgene]["tngp"]) + '";"' + str(Trait[currentgene]["tpgn"]) + \
 			'";"' + str(Trait[currentgene]["tngn"]) + '";"' + str(Trait[currentgene]["sens"]) + '";"' + str(Trait[currentgene]["spes"]) + \


### PR DESCRIPTION
Major changes, as documented in what's new: 

v1.3.0 (1st Jun 2016)
- Major changes to the pairwise comparisons algorithm. Scoary now calculates the maximum number of contrasting pairs, and given that maximum number tests the maximum number of pairs that SUPPORT A -> B (AB-ab pairs) and the maximum number of pairs that OPPOSE A -> B (Ab-aB pairs). The opposite is true for genes where the odds ratio is < 1 (i.e. that indicate A -> b).
- The p-values reported from the pairwise comparisons is now a range. It reports the best (lowest) p-value, which comes from the maximum number of supporting pairs and the minimum number of opposing (given a set total), as well as the worst (highest) p-value, which comes from the minimum number of supporting pairs and the maximum number of non-supporting, given a set total number of pairings. It does this at each node in the tree.
- Scoary can now print the UPGMA tree that is calculated internally from the Hamming distances of the gene_presence_absence matrix. Do this by using the -u flag.
- The elapsed time will now print when finished.