### PR TITLE
fix ValueError: invalid mode: 'rU' with python3.11

### DIFF
--- a/scoary/methods.py
+++ b/scoary/methods.py
@@ -181,15 +181,15 @@ def main(**kwargs):
                 cutoffs.pop(m,None)
             
         # Start analysis
-        with open(args.genes, "rU") as genes, \
-        open(args.traits, "rU") as traits:
+        with open(args.genes, "r") as genes, \
+        open(args.traits, "r") as traits:
     
             if args.restrict_to is not None:
                 # Note: Despite being a dictionary, the values of
                 # allowed_isolates are not currently used, only the keys
                 allowed_isolates = {isolate : "all"
                                     for line in
-                                    open(args.restrict_to,"rU")
+                                    open(args.restrict_to,"r")
                                     for isolate in line.rstrip().split(",")}
             else:
                 # Despite the confusing name
@@ -343,7 +343,7 @@ def Csv_to_dic_Roary(genefile, delimiter, grabcols, startcol=14,
 
     if writereducedset:
         file = open(ReduceSet(genefile,delimiter, grabcols, startcol,
-                    allowed_isolates,time,outdir),"rU")
+                    allowed_isolates,time,outdir),"r")
         csvfile = csv.reader(file, skipinitialspace=True, 
                              delimiter=delimiter)
     else:

--- a/scoary/vcf2scoary.py
+++ b/scoary/vcf2scoary.py
@@ -100,7 +100,7 @@ def main():
     if not os.path.isfile(args.vcf):
         sys.exit("Unable to locate input file %s" % args.vcf)
 
-    with open(args.vcf,'rU') as vcffile, open(args.out,'w') as outfile:
+    with open(args.vcf,'r') as vcffile, open(args.out,'w') as outfile:
         lines = csv.reader(vcffile, delimiter='\t', quotechar='"')
         metainfo = {"##INFO" : {},
                     "##FILTER" : {},

--- a/tests/test_scoary_output.py
+++ b/tests/test_scoary_output.py
@@ -20,7 +20,7 @@ referencevcf = ["NC_000962", "4013","0","T","C","9999","0","TYPE=snp","GT","Fals
 
 
 for Test in ["1","2","4"]:
-    with open(os.getcwd() + "/Test" + Test + "/Tetracycline_resistance.results.csv" ,"rU") as resfile:
+    with open(os.getcwd() + "/Test" + Test + "/Tetracycline_resistance.results.csv" ,"r") as resfile:
         tab = csv.reader(resfile, delimiter=",")
         for i in range(2):
             if i == 0:
@@ -120,7 +120,7 @@ for Test in ["1","2","4"]:
                         print("Not equal at Test %s col 17: %s %s" % (Test, data[17], str(reference[17])))
                         sys.exit(-1)
 
-with open(os.getcwd() + "/mutations_presence_absence.csv" ,"rU") as vcfresfile:
+with open(os.getcwd() + "/mutations_presence_absence.csv" ,"r") as vcfresfile:
     tab = csv.reader(vcfresfile, delimiter=",")
     for i in range(2):
         if i == 0:


### PR DESCRIPTION
Since python3, the universal newline mode 'U' has no effects. Since python3.11, that mode is obsolete and its use raises:

	Command: scoary.py -g scoary/exampledata/Gene_presence_absence.csv -t scoary/exa
	mpledata/Tetracycline_resistance.csv -o Test1 --no-time
	Traceback (most recent call last):
	  File "/<<PKGBUILDDIR>>/scoary.py", line 25, in <module>
	    methods.main()
	  File "/<<PKGBUILDDIR>>/scoary/methods.py", line 184, in main
	    with open(args.genes, "rU") as genes, \
	         ^^^^^^^^^^^^^^^^^^^^^^
	ValueError: invalid mode: 'rU'

Note this patch suppresses various references to the 'U' mode in calls to the "open" function, which most likely breaks compatibility of Scoary with python2.  Given that this interpreter version is out of maintenance since 2020, it should not be too problematic.