### PR TITLE
Migrate to SciPy 1.12.0.

### DIFF
--- a/scoary/methods.py
+++ b/scoary/methods.py
@@ -1264,15 +1264,15 @@ def PairWiseComparisons(nestedlist):
             Pbest = "Pworst"
             Pworst = "Pbest"
         try:
-            resultscontainer[currentgene][Pbest] = ss.binom_test(
+            resultscontainer[currentgene][Pbest] = ss.binomtest(
                 resultscontainer[currentgene]["max_propairs"],
                 resultscontainer[currentgene]["max_total_pairs"],
-                0.5)
-            resultscontainer[currentgene][Pworst] = ss.binom_test(
+                0.5).pvalue
+            resultscontainer[currentgene][Pworst] = ss.binomtest(
                 resultscontainer[currentgene]["max_total_pairs"] - 
                 resultscontainer[currentgene]["max_antipairs"],
                 resultscontainer[currentgene]["max_total_pairs"],
-                0.5)
+                0.5).pvalue
             resultscontainer[currentgene]["Plowest"] = min(
                 resultscontainer[currentgene]["Pbest"], 
                 resultscontainer[currentgene]["Pworst"])
@@ -1281,7 +1281,7 @@ def PairWiseComparisons(nestedlist):
                 resultscontainer[currentgene]["Pworst"])
         except TypeError:
             sys.exit("There was a problem using " 
-            "scipy.stats.binom_test. Ensure you have a recent "
+            "scipy.stats.binomtest. Ensure you have a recent "
             "distribution of SciPy installed.")
 
         # Loop can break early if filtration includes non-pairwise 


### PR DESCRIPTION
Deprecated function [scipy.stats.binom_test] expired in scipy 1.12.0 to be replaced by [scipy.stats.binomtest].  This patch is a quick fix to port to the newer API.  Error handling revolving around the binomial test might make less sense now though, but it's left to keep the change relatively targeted.

This issue was initially identified in [Debian bug #1071702].

[scipy.stats.binom_test]: https://docs.scipy.org/doc/scipy-1.11.0/reference/generated/scipy.stats.binom_test.html#scipy.stats.binom_test
[scipy.stats.binomtest]: https://docs.scipy.org/doc/scipy-1.12.0/reference/generated/scipy.stats.binomtest.html#scipy.stats.binomtest
[Debian bug #1071702]: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1071702