### PR TITLE
vcf2scoary.py: fix SyntaxWarnings.

### DIFF
--- a/scoary/vcf2scoary.py
+++ b/scoary/vcf2scoary.py
@@ -91,7 +91,7 @@ def main():
         help='The VCF file to convert to Roary/Scoary format')
 
     args = parser.parse_args()
-    if args.types is not "ALL":
+    if args.types != "ALL":
         args.types = args.types.split(",")
 
     if os.path.isfile(args.out) and not args.force:
@@ -169,7 +169,7 @@ def main():
                 print("Reached the end of the file")
                 sys.exit(0)
             # Check if line is allowed:
-            if args.types is not "ALL":
+            if args.types != "ALL":
                 vartype = re.search(r'TYPE=(\w+)',line[7]).group(1)
                 if vartype not in args.types:
                     continue


### PR DESCRIPTION
With contemporary Python versions like 3.13, Scoary emits the following warnings:

	  /usr/lib/python3/dist-packages/scoary/vcf2scoary.py:94: SyntaxWarning: "is not" with 'str' literal. Did you mean "!="?
	    if args.types is not "ALL":
	  /usr/lib/python3/dist-packages/scoary/vcf2scoary.py:172: SyntaxWarning: "is not" with 'str' literal. Did you mean "!="?
	    if args.types is not "ALL":

Applying the hint resolves the issue.

This issue has initially been reported as [Debian bug #1087074].

[Debian bug #1087074]: https://bugs.debian.org/1087074